### PR TITLE
Lock extract-opts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "coffee-script": "^1.9.0",
     "cson-parser": "^1.0.6",
-    "extract-opts": "^3.0.1",
+    "extract-opts": "3.0.1",
     "requirefresh": "^2.0.0",
     "safefs": "^4.0.0"
   },


### PR DESCRIPTION
`extract-opts` updated earlier today to `3.1.0`: https://github.com/bevry/extract-opts/releases/tag/v3.1.0

Because of this, I was getting this error: `ReferenceError: Symbol is not defined`

This PR locks `extract-opts` at 3.0.1